### PR TITLE
OutputView.clear() didn't check if blocks was empty

### DIFF
--- a/src/org/sagemath/droid/OutputView.java
+++ b/src/org/sagemath/droid/OutputView.java
@@ -188,7 +188,8 @@ public class OutputView
 		} catch (Exception e) {
 			Log.e(TAG, "Error clearing output blocks " + e.getLocalizedMessage());
 		}
-		cell.clearCache();
+		if (cell != null)
+			cell.clearCache();
 	}
 
 	@Override


### PR DESCRIPTION
The first commit fixes the first error in #9, the second the second. This is a quick fix without understanding if the fixed code is correct, at all.
