### PR TITLE
Add support for building using Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,32 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath "com.android.tools.build:gradle:0.8.+"
+    }
+}
+
+apply plugin: "android"
+
+android {
+    compileSdkVersion 19
+    buildToolsVersion "19.0.1"
+
+    sourceSets {
+        main {
+            manifest.srcFile "AndroidManifest.xml"
+            java.srcDir "src"
+            res.srcDir "res"
+        }
+    }
+}
+
+dependencies {
+    repositories {
+        mavenCentral()
+    }
+
+    compile "com.android.support:support-v4:19.0.+"
+}


### PR DESCRIPTION
Gradle is the [next-gen build system](http://tools.android.com/tech-docs/new-build-system) for Android. It is used in combination with [Android Studio](http://developer.android.com/sdk/installing/studio.html) or as a standalone tool from console.

This change is pretty basic and doesn’t ruin anything, just adds an ability to build the app using Gradle + Android Studio as well as Ant + Eclipse. In perspective, Gradle allows to remove inner dependencies at the `src` and `libs` directories, but this change will require to abandon Eclipse in favour of Android Studio. Does it make sense or current approach is totally fine with everyone?
