### PR TITLE
Fix gradle-wrapper.properties & update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ gen/
 
 # Local configuration file (sdk path, etc)
 local.properties
+release.properties
+ant.properties
 
 # Eclipse project files
 .classpath
@@ -38,3 +40,16 @@ proguard/
 *.ipr
 *.iws
 .idea/
+
+#gradle
+.gradle
+build
+gradle.properties
+
+#IntelliJ IDEA
+.idea
+*.iml
+
+#Maven
+target
+pom.xml.*

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Feb 28 12:51:21 IST 2014
+#Sat Mar 01 10:26:54 IST 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.9-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip


### PR DESCRIPTION
Sorry, apparently Android Studio created the wrapper with the wrong gradle version.

This should fix the org.gradle.api.artifacts.result.ResolvedComponentResult error mentioned by @parane.
